### PR TITLE
#Redirect users to post detail

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,7 +16,7 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.new(post_params)
     if @post.save
-      redirect_to new_post_path, notice: 'Post created successfully'
+      redirect_to post_path(@post), notice: 'Post created successfully'
     else
       render 'new'
     end

--- a/spec/controllers/posts/create_spec.rb
+++ b/spec/controllers/posts/create_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe PostsController, type: :controller do
           post :create, params: post_attributes
         end
 
-        it 'redirects to posts#new' do
-          expect(response).to redirect_to(new_post_url)
+        it 'redirects to posts#show' do
+          expect(response).to redirect_to(post_path(Post.last.id))
         end
 
         it 'adds new post to database' do

--- a/spec/features/posts/create_spec.rb
+++ b/spec/features/posts/create_spec.rb
@@ -28,7 +28,7 @@ feature 'add new post' do
         end
 
         expect(page).to have_content('Post created successfully')
-        expect(page.current_path).to eq(new_post_path)
+        expect(page.current_path).not_to eq(new_post_path)
       end
     end
 


### PR DESCRIPTION
- initially users were redirected to new_post_path which
  does not make sense, it  makes sense for a user to see
  post (s)he created after clicking save button