### PR TITLE
#Fix post creation date

### DIFF
--- a/app/assets/javascripts/ui/posts_ui.coffee
+++ b/app/assets/javascripts/ui/posts_ui.coffee
@@ -5,7 +5,9 @@ class Posts.UI
 
   renderTimeSince: ->
     $("small#post-time").each (_, obj) ->
-      timesince = moment(obj.innerText).fromNow()
+      created_at = obj.innerText
+      return obj if isNaN(Date.parse(created_at))
+      timesince = moment(created_at).fromNow()
       this.innerHTML = timesince
 
   truncatePostContent: ->


### PR DESCRIPTION
### Steps to reproduce
1. Visit posts list page and observe post creation date.
2. Click on any post then click the back arrow to posts list page again and observe `Invalid date` text where post creation date is supposed to be.
